### PR TITLE
Predictable container name

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,7 @@ services:
   ocr:
     build: .
     image: ghcr.io/viespirkiu-grupe/ocr:latest
+    container_name: ocr
     restart: unless-stopped
     env_file:
       - ./.env


### PR DESCRIPTION
Set container name in compose, so it's always `ocr` which makes it a bit more predictable and less dependant on docker/podman compose which seems to flip-flop between `ocr-ocr-1` and `ocr_ocr_1`.